### PR TITLE
Add sleep after docker restart in setup-worker.sh

### DIFF
--- a/setup-worker.sh
+++ b/setup-worker.sh
@@ -19,6 +19,8 @@ echo 'DOCKER_OPTS="--icc=false --exec-driver=lxc '$DOCKER_MOUNT_POINT'"' >> /etc
 
 service docker restart
 
+sleep 2
+
 docker pull quay.io/travisci/te-worker:latest
 docker tag quay.io/travisci/te-worker te-worker
 


### PR DESCRIPTION
Fixing bug, when restarting docker is to slow in setup-worker.sh

<pre>
+ apt-get install -y linux-image-extra-3.13.0-36-generic lxc lxc-docker-1.0.0
Reading package lists... Done
Building dependency tree
Reading state information... Done
linux-image-extra-3.13.0-36-generic is already the newest version.
lxc is already the newest version.
lxc-docker-1.0.0 is already the newest version.
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
+ [[ -n '' ]]
+ echo 'DOCKER_OPTS="--icc=false --exec-driver=lxc "'
+ service docker restart
docker stop/waiting
docker start/running, process 3781
+ docker pull quay.io/travisci/te-worker:latest
2015/01/05 12:20:57 Cannot connect to the Docker daemon. Is 'docker -d' running on this host?
</pre>