### PR TITLE
http->https for docker APT repo

### DIFF
--- a/setup-worker.sh
+++ b/setup-worker.sh
@@ -5,7 +5,7 @@ set -e
 export DEBIAN_FRONTEND=noninteractive
 wget -qO- https://get.docker.io/gpg | apt-key add -
  
-echo deb http://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list
+echo deb https://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list
 apt-get update
  
 apt-get install -y linux-image-extra-`uname -r` lxc lxc-docker-1.0.0


### PR DESCRIPTION
The http version was throwing errors for us, maybe it was deprecated? Either way, this is more secure.